### PR TITLE
Allow specifying schema names other than the default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,17 @@ extern crate diesel;
 
 mod column;
 mod dummy_expression;
+mod schema;
 mod table;
 
 pub use column::Column;
+pub use schema::Schema;
 pub use table::Table;
 
 pub fn table<T>(name: T) -> Table<T> {
     Table::new(name)
+}
+
+pub fn schema<T>(name: T) -> Schema<T> {
+    Schema::new(name)
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,19 @@
+use table::Table;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Schema<T> {
+    name: T,
+}
+
+impl<T> Schema<T> {
+    pub(crate) fn new(name: T) -> Self {
+        Self { name }
+    }
+
+    pub fn table<U>(&self, name: U) -> Table<U, T>
+    where
+        T: Clone,
+    {
+        Table::with_schema(self.name.clone(), name)
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -9,16 +9,27 @@ use column::Column;
 use dummy_expression::*;
 
 #[derive(Debug, Clone, Copy)]
-pub struct Table<T> {
+pub struct Table<T, U=T> {
     name: T,
+    schema: Option<U>,
 }
 
-impl<T> Table<T> {
+impl<T, U> Table<T, U> {
     pub(crate) fn new(name: T) -> Self {
-        Self { name }
+        Self {
+            name,
+            schema: None,
+        }
     }
 
-    pub fn column<ST, U>(&self, name: U) -> Column<Self, U, ST>
+    pub(crate) fn with_schema(schema: U, name: T) -> Self {
+        Self {
+            name,
+            schema: Some(schema),
+        }
+    }
+
+    pub fn column<ST, V>(&self, name: V) -> Column<Self, V, ST>
     where
         Self: Clone,
     {
@@ -26,7 +37,7 @@ impl<T> Table<T> {
     }
 }
 
-impl<T> QuerySource for Table<T>
+impl<T, U> QuerySource for Table<T, U>
 where
     Self: Clone,
 {
@@ -42,7 +53,7 @@ where
     }
 }
 
-impl<T> AsQuery for Table<T>
+impl<T, U> AsQuery for Table<T, U>
 where
     SelectStatement<Self>: Query<SqlType = ()>,
 {
@@ -54,7 +65,7 @@ where
     }
 }
 
-impl<T> diesel::Table for Table<T>
+impl<T, U> diesel::Table for Table<T, U>
 where
     Self: QuerySource + AsQuery,
 {
@@ -70,19 +81,26 @@ where
     }
 }
 
-impl<T, DB> QueryFragment<DB> for Table<T>
+impl<T, U, DB> QueryFragment<DB> for Table<T, U>
 where
     DB: Backend,
     T: Borrow<str>,
+    U: Borrow<str>,
 {
     fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
+
+        if let Some(ref schema) = self.schema {
+            out.push_identifier(schema.borrow())?;
+            out.push_sql(".");
+        }
+
         out.push_identifier(self.name.borrow())?;
         Ok(())
     }
 }
 
-impl<T> QueryId for Table<T> {
+impl<T, U> QueryId for Table<T, U> {
     type QueryId = ();
     const HAS_STATIC_QUERY_ID: bool = false;
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,7 +3,8 @@ extern crate diesel_dynamic_schema;
 
 use diesel::*;
 use diesel::sql_types::*;
-use diesel_dynamic_schema::table;
+use diesel::sqlite::Sqlite;
+use diesel_dynamic_schema::{schema, table};
 
 #[test]
 fn querying_basic_schemas() {
@@ -56,6 +57,13 @@ fn columns_used_in_where_clause() {
         .filter(name.eq("Sean"))
         .load::<(i32, String)>(&conn);
     assert_eq!(Ok(vec![(1, "Sean".into())]), users);
+}
+
+#[test]
+fn providing_custom_schema_name() {
+    let table = schema("information_schema").table("users");
+    let sql = debug_query::<Sqlite, _>(&table);
+    assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
 }
 
 fn establish_connection() -> SqliteConnection {


### PR DESCRIPTION
The test for this feature is a bit wonky. This feature only matters for
PG, but I don't want to dick around with setting up test suites for
multiple backends on such a simple crate. Instead we can just test the
generated SQL directly.