### PR TITLE
Add documentation with examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,21 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 diesel = "1.0.0"
 
+[[example]]
+name = "querying_basic_schemas"
+path = "examples/querying_basic_schemas.rs"
+required-features = ["diesel/sqlite"]
+
+[[example]]
+name = "querying_multiple_types"
+path = "examples/querying_multiple_types.rs"
+required-features = ["diesel/sqlite"]
+
+[[example]]
+name = "columns_used_in_where_clause"
+path = "examples/columns_used_in_where_clause.rs"
+required-features = ["diesel/sqlite"]
+
 [[test]]
 name = "integration_tests"
 path = "tests/lib.rs"

--- a/examples/columns_used_in_where_clause.rs
+++ b/examples/columns_used_in_where_clause.rs
@@ -37,8 +37,7 @@ fn main() {
     // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
     let users = users.unwrap();
     for (user_id, user_name) in users {
-        let (x, y) = user;
-        println!("user id:{} name:{}", x, y);
+        println!("user id:{} name:{}", user_id, user_name);
     }
 
 }

--- a/examples/columns_used_in_where_clause.rs
+++ b/examples/columns_used_in_where_clause.rs
@@ -1,0 +1,44 @@
+//! Example: columns used in where clause
+//!
+//! To run this:
+//!
+//! ```sh
+//! cargo run --example columns_used_in_where_clause --features="diesel/sqlite"
+//! ```
+extern crate diesel;
+extern crate diesel_dynamic_schema;
+
+use diesel::*;
+use diesel::sql_types::{Integer, Text};
+use diesel::sqlite::SqliteConnection;
+use diesel_dynamic_schema::table;
+
+fn main() {
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+
+    // Create some example data by using typical SQL statements.
+    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
+
+    // Use diesel-dynamic-schema to create a table and a column.
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    // Use typical Diesel syntax to get some data.
+    // This uses a filter on name equal to "Sean",
+    // which generates a SQL `where` clause.
+    let users = users
+        .select((id, name))
+        .filter(name.eq("Sean"))
+        .load::<(i32, String)>(&conn);
+
+    // Print the results.
+    // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
+    let users = users.unwrap();
+    for user in users {
+        let (x, y) = user;
+        println!("user id:{} name:{}", x, y);
+    }
+
+}

--- a/examples/columns_used_in_where_clause.rs
+++ b/examples/columns_used_in_where_clause.rs
@@ -36,7 +36,7 @@ fn main() {
     // Print the results.
     // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
     let users = users.unwrap();
-    for user in users {
+    for (user_id, user_name) in users {
         let (x, y) = user;
         println!("user id:{} name:{}", x, y);
     }

--- a/examples/querying_basic_schemas.rs
+++ b/examples/querying_basic_schemas.rs
@@ -34,7 +34,7 @@ fn main() {
     // The `ids` are type `std::result::Result<std::vec::Vec<i32>, diesel::result::Error>`.
     let ids = ids.unwrap();
     for x in ids {
-        println!("id:{}", x);
+        println!("user id:{}", x);
     }
 
 }

--- a/examples/querying_basic_schemas.rs
+++ b/examples/querying_basic_schemas.rs
@@ -1,0 +1,40 @@
+//! Example: querying basic schemas
+//!
+//! To run this:
+//!
+//! ```sh
+//! cargo run --example querying_basic_schemas --features="diesel/sqlite"
+//! ```
+extern crate diesel;
+extern crate diesel_dynamic_schema;
+
+use diesel::*;
+use diesel::sql_types::Integer;
+use diesel::sqlite::SqliteConnection;
+use diesel_dynamic_schema::table;
+
+fn main() {
+    // Create a connection; we are using a simple Sqlite memory database.
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+
+    // Create some example data by using typical SQL statements.
+    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
+
+    // Use diesel-dynamic-schema to create a table and a column.
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+
+    // Use typical Diesel syntax to get some data.
+    let ids = users
+        .select(id)
+        .load::<i32>(&conn);
+
+    // Print the results.
+    // The `ids` are type `std::result::Result<std::vec::Vec<i32>, diesel::result::Error>`.
+    let ids = ids.unwrap();
+    for x in ids {
+        println!("id:{}", x);
+    }
+
+}

--- a/examples/querying_multiple_types.rs
+++ b/examples/querying_multiple_types.rs
@@ -35,7 +35,6 @@ fn main() {
     // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
     let users = users.unwrap();
     for (user_id, user_name) in users {
-        let (x, y) = user;
-        println!("user id:{} name:{}", x, y);
+        println!("user id:{} name:{}", user_id, user_name);
     }
 }

--- a/examples/querying_multiple_types.rs
+++ b/examples/querying_multiple_types.rs
@@ -34,7 +34,7 @@ fn main() {
     // Print the results.
     // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
     let users = users.unwrap();
-    for user in users {
+    for (user_id, user_name) in users {
         let (x, y) = user;
         println!("user id:{} name:{}", x, y);
     }

--- a/examples/querying_multiple_types.rs
+++ b/examples/querying_multiple_types.rs
@@ -1,0 +1,41 @@
+//! Example: querying multiple types
+//!
+//! To run this:
+//!
+//! ```sh
+//! cargo run --example querying_mutiple_types --features="diesel/sqlite"
+//! ```
+extern crate diesel;
+extern crate diesel_dynamic_schema;
+
+use diesel::*;
+use diesel::sql_types::{Integer, Text};
+use diesel::sqlite::SqliteConnection;
+use diesel_dynamic_schema::table;
+
+fn main() {
+    // Create a connection; we are using a simple Sqlite memory database.
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+
+    // Create some example data by using typical SQL statements.
+    sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
+
+    // Use diesel-dynamic-schema to create a table and a column.
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    // Use typical Diesel syntax to get some data.
+    let users = users
+        .select((id, name))
+        .load::<(i32, String)>(&conn);
+
+    // Print the results.
+    // The `users` are type `std::result::Result<std::vec::Vec<(i32, std::string::String)>, diesel::result::Error>`
+    let users = users.unwrap();
+    for user in users {
+        let (x, y) = user;
+        println!("user id:{} name:{}", x, y);
+    }
+}

--- a/src/column.rs
+++ b/src/column.rs
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Copy)]
 /// A database table column.
+/// This type is created by the [`column`](struct.Table.html#method.column) function.
 pub struct Column<T, U, ST> {
     table: T,
     name: U,

--- a/src/column.rs
+++ b/src/column.rs
@@ -6,6 +6,7 @@ use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Copy)]
+/// A database table column.
 pub struct Column<T, U, ST> {
     table: T,
     name: U,

--- a/src/dummy_expression.rs
+++ b/src/dummy_expression.rs
@@ -1,6 +1,7 @@
 use diesel::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExpression};
 
 #[doc(hidden)]
+/// A dummy expression.
 pub struct DummyExpression;
 
 impl DummyExpression {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! // Create some example data by using typical SQL statements.
 //! sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
-//! sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
+//! # sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
 //!
 //! // Use diesel-dynamic-schema to create a table.
 //! let users = table("users");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@
 //!     .load::<(i32, String)>(&conn);
 //!
 //! let results = results.unwrap();
+//! # assert_eq!(results.len(), 1);
+//! # assert_eq!(results[0].1, "Sean");
 //! for result in results {
 //!    let (x, y) = result;
 //!        println!("id:{} name:{}", x, y);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,6 @@ pub use table::Table;
 
 /// Create a new table with the given name.
 ///
-/// # Arguments
-///
-/// * `name` - A string slice that holds the name of the person
-///
 /// # Example
 ///
 /// ```
@@ -107,10 +103,6 @@ pub fn table<T>(name: T) -> Table<T> {
 }
 
 /// Create a new schema with the given name.
-///
-/// # Arguments
-///
-/// * `name` - A string slice that holds the name of the person
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! use diesel::sqlite::SqliteConnection;
 //! use diesel_dynamic_schema::table;
 //! 
-//! let conn = SqliteConnection::establish(":memory:").unwrap();
+//! # let conn = SqliteConnection::establish(":memory:").unwrap();
 //!
 //! // Create some example data by using typical SQL statements.
 //! sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@
 //! 
 //! # Getting Started
 //! 
-//! The main function used by this crate is `table`. Note that you must always
-//! provide an explicit select clause when using this crate.
+//! The `table` function is used to create a new Diesel table.
+//! Note that you must always provide an explicit select clause 
+//! when using this crate.
 //! 
 //! Runnable example:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use schema::Schema;
 /// A database table.
 pub use table::Table;
 
-/// Create a new table with the given name.
+/// Create a new [`Table`](struct.Table.html) with the given name.
 ///
 /// # Example
 ///
@@ -102,7 +102,7 @@ pub fn table<T>(name: T) -> Table<T> {
     Table::new(name)
 }
 
-/// Create a new schema with the given name.
+/// Create a new [`Schema`](struct.Schema.html) with the given name.
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,8 @@
 //! sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
 //! # sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
 //!
-//! // Use diesel-dynamic-schema to create a table.
+//! // Use diesel-dynamic-schema to create a table and columns.
 //! let users = table("users");
-//!
-//! // Use diesel-dynamic-schema to create some table columns.
 //! let id = users.column::<Integer, _>("id");
 //! let name = users.column::<Text, _>("name");
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,22 +26,20 @@
 //! Note that you must always provide an explicit select clause 
 //! when using this crate.
 //! 
-//! Runnable example:
-//!
 //! ```rust
-//! extern crate diesel;
-//! extern crate diesel_dynamic_schema;
-//! use diesel::*;
-//! use diesel::sql_types::{Integer, Text};
-//! use diesel::sqlite::SqliteConnection;
-//! use diesel_dynamic_schema::table;
-//! 
+//! # extern crate diesel;
+//! # extern crate diesel_dynamic_schema;
+//! # use diesel::*;
+//! # use diesel::sql_types::{Integer, Text};
+//! # use diesel::sqlite::SqliteConnection;
+//! # use diesel_dynamic_schema::table;
+//! #
 //! # let conn = SqliteConnection::establish(":memory:").unwrap();
-//!
-//! // Create some example data by using typical SQL statements.
-//! sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
+//! #
+//! # // Create some example data by using typical SQL statements.
+//! # sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)").execute(&conn).unwrap();
 //! # sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')").execute(&conn).unwrap();
-//!
+//! #
 //! // Use diesel-dynamic-schema to create a table and columns.
 //! let users = table("users");
 //! let id = users.column::<Integer, _>("id");
@@ -60,6 +58,8 @@
 //! }
 //! ```
 //! 
+//! See the `/examples` directory for runnable code examples.
+//!
 //! ## Getting help
 //!
 //! If you run into problems, Diesel has a very active Gitter room.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,7 @@
 use table::Table;
 
 #[derive(Debug, Clone, Copy)]
+/// A database schema.
 pub struct Schema<T> {
     name: T,
 }
@@ -10,6 +11,7 @@ impl<T> Schema<T> {
         Self { name }
     }
 
+    /// Create a table with this schema.
     pub fn table<U>(&self, name: U) -> Table<U, T>
     where
         T: Clone,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,6 +2,7 @@ use table::Table;
 
 #[derive(Debug, Clone, Copy)]
 /// A database schema.
+/// This type is created by the [`schema`](fn.schema.html) function.
 pub struct Schema<T> {
     name: T,
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -10,6 +10,7 @@ use dummy_expression::*;
 
 #[derive(Debug, Clone, Copy)]
 /// A database table.
+/// This type is created by the [`table`](fn.table.html) function.
 pub struct Table<T, U = T> {
     name: T,
     schema: Option<U>,

--- a/src/table.rs
+++ b/src/table.rs
@@ -9,6 +9,7 @@ use column::Column;
 use dummy_expression::*;
 
 #[derive(Debug, Clone, Copy)]
+/// A database table.
 pub struct Table<T, U = T> {
     name: T,
     schema: Option<U>,
@@ -26,6 +27,7 @@ impl<T, U> Table<T, U> {
         }
     }
 
+    /// Create a column with this table.
     pub fn column<ST, V>(&self, name: V) -> Column<Self, V, ST>
     where
         Self: Clone,


### PR DESCRIPTION
Add documentation that is a starting point sufficient to satisfy cargo docs.

Add examples that are based on the test coverage code.

Add lint because this helps prepare a crate for publishing to crates.io:

```rust
#![deny(
    missing_docs
)]
```

To compile the example files and example `lib.rs` code, use the sqlite flag:

```sh
$ cargo test --features="diesel/sqlite"
```

To run an example, use the sqlite flag:

```sh
$ cargo run --example columns_used_in_where_clause --features="diesel/sqlite"
```
