### PR TITLE
Implemented Display for columns and tables

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -3,6 +3,7 @@ use diesel::expression::{AppearsOnTable, Expression, NonAggregate, SelectableExp
 use diesel::prelude::*;
 use diesel::query_builder::*;
 use std::borrow::Borrow;
+use std::fmt;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Copy)]
@@ -18,7 +19,7 @@ impl<T, U, ST> Column<T, U, ST> {
     pub(crate) fn new(table: T, name: U) -> Self {
         Self {
             table,
-            name: name,
+            name,
             _sql_type: PhantomData,
         }
     }
@@ -51,5 +52,14 @@ where
         out.push_sql(".");
         out.push_identifier(self.name.borrow())?;
         Ok(())
+    }
+}
+
+impl<T, U, ST> fmt::Display for Column<T, U, ST>
+where
+    U: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -4,6 +4,7 @@ use diesel::prelude::*;
 use diesel::query_builder::*;
 use diesel::query_source::QuerySource;
 use std::borrow::Borrow;
+use std::fmt;
 
 use column::Column;
 use dummy_expression::*;
@@ -103,4 +104,13 @@ where
 impl<T, U> QueryId for Table<T, U> {
     type QueryId = ();
     const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<T, U> fmt::Display for Table<T, U>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -69,3 +69,12 @@ fn providing_custom_schema_name() {
 fn establish_connection() -> SqliteConnection {
     SqliteConnection::establish(":memory:").unwrap()
 }
+
+#[test]
+fn display_for_columns_and_tables() {
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+
+    assert_eq!(format!("{}", users), "users");
+    assert_eq!(format!("{}", id), "id");
+}


### PR DESCRIPTION
This implements `std::fmt::Display` for `Column` and `Table`, as explained in #12.